### PR TITLE
Clean up repair_names()

### DIFF
--- a/R/repair-column-names.R
+++ b/R/repair-column-names.R
@@ -45,5 +45,5 @@ init_names <- function(x) {
   if (is.null(xnames))
     rep("", length(x))
   else
-    ifelse(is.na(xnames), "", trimws(xnames))
+    ifelse(is.na(xnames), "", trim_ws(xnames))
 }

--- a/R/repair-column-names.R
+++ b/R/repair-column-names.R
@@ -25,9 +25,8 @@ repair_names <- function(x, prefix = "V", sep = "") {
 
 init_names <- function(x) {
   xnames <- names(x)
-  if (is.null(xnames)) {
+  if (is.null(xnames))
     rep("", length(x))
-  } else {
-    ifelse(is.na(xnames) | grepl("^ +$", xnames), "", xnames)
-  }
+  else
+    ifelse(is.na(xnames), "", trimws(xnames))
 }

--- a/R/repair-column-names.R
+++ b/R/repair-column-names.R
@@ -9,26 +9,25 @@
 #' @return data.frame with possibly-repaired column names
 #' @export
 repair_names <- function(x, prefix = "V", sep = "") {
-  if (! isTRUE(length(x) > 0)) return(x)
-  xnames <- names(x)
-  xnames <-
-    if (is.null(xnames)) {
-      rep('', length(x))
-    } else {
-      ifelse(is.na(xnames) | grepl('^ +$', xnames), '', xnames)
-    }
-  blanks <- xnames == ''
+  if (length(x) == 0)
+    return(x)
 
-  sub_names <- xnames[!blanks]
-  sub_names <- make.unique(sub_names, sep = sep)
-  xnames[!blanks] <- sub_names
+  xnames <- init_names(x)
+  blanks <- xnames == ""
+  order <- c(which(!blanks), which(blanks))
 
-  if (any(blanks)) {
-    new_names <- paste(prefix, 1:length(x), sep = sep)
-    new_names <- head(setdiff(new_names, xnames), n = sum(blanks))
-    xnames[blanks] <- new_names
-  }
+  xnames[blanks] <- prefix
+  xnames[order] <- make.unique(xnames[order], sep = sep)
 
   names(x) <- xnames
   x
+}
+
+init_names <- function(x) {
+  xnames <- names(x)
+  if (is.null(xnames)) {
+    rep("", length(x))
+  } else {
+    ifelse(is.na(xnames) | grepl("^ +$", xnames), "", xnames)
+  }
 }

--- a/R/repair-column-names.R
+++ b/R/repair-column-names.R
@@ -14,8 +14,17 @@ repair_names <- function(x, prefix = "V", sep = "") {
 
   xnames <- init_names(x)
   blanks <- xnames == ""
-  order <- c(which(!blanks), which(blanks))
 
+  # The order vector defines the order in which make.unique() should process the
+  # entries.  Blanks are initialized with the prefix. The index of the first
+  # blank entry appears twice in this vector if there's no column named like the
+  # prefix, to make sure that blank columns always start with V1 (or a higher
+  # index if appropriate).  See also the "pathological cases" test.
+  order <- c(
+    which(!blanks),
+    if (all(xnames[!blanks] != prefix) && any(blanks))
+      which.max(blanks),
+    which(blanks))
   xnames[blanks] <- prefix
   xnames[order] <- make.unique(xnames[order], sep = sep)
 

--- a/R/repair-column-names.R
+++ b/R/repair-column-names.R
@@ -1,13 +1,21 @@
 #' Check validity/format of a data.frame or tbl.
 #'
-#' Ensure the tbl or data.frame has legitimate and optionally unique
-#' column names.
-#' @param x tbl, tbl_df, or data.frame
+#' Ensure the object (e.g., tbl, data.frame or list) has legitimate and unique
+#' names without leading or trailing blanks.
+#'
+#' The function does not change any names that are correct already.
+#'
+#' @param x named object
 #' @param prefix character, the prefix to use for new column names
 #' @param sep character, a character string to separate the terms. Not
 #'     \code{NA_character_}.
-#' @return data.frame with possibly-repaired column names
+#' @return input with reparied names
 #' @export
+#' @examples
+#' repair_names(list(3, 4, 5)) # works for lists, too
+#' repair_names(mtcars) # a no-op
+#' tbl <- as_data_frame(structure(list(3, 4, 5), class = "data.frame"))
+#' repair_names(tbl)
 repair_names <- function(x, prefix = "V", sep = "") {
   if (length(x) == 0)
     return(x)

--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -194,3 +194,6 @@ big_mark <- function(x, ...) {
   mark <- if (identical(getOption("OutDec"), ",")) "." else ","
   formatC(x, big.mark = mark, ...)
 }
+
+# trimws() is not available in R 3.1.3
+trim_ws <- function(x) gsub("^ *(|(.*[^ ])) *$", "\\1", x)

--- a/man/repair_names.Rd
+++ b/man/repair_names.Rd
@@ -7,7 +7,7 @@
 repair_names(x, prefix = "V", sep = "")
 }
 \arguments{
-\item{x}{tbl, tbl_df, or data.frame}
+\item{x}{named object}
 
 \item{prefix}{character, the prefix to use for new column names}
 
@@ -15,10 +15,19 @@ repair_names(x, prefix = "V", sep = "")
 \code{NA_character_}.}
 }
 \value{
-data.frame with possibly-repaired column names
+input with reparied names
 }
 \description{
-Ensure the tbl or data.frame has legitimate and optionally unique
-column names.
+Ensure the object (e.g., tbl, data.frame or list) has legitimate and unique
+names without leading or trailing blanks.
+}
+\details{
+The function does not change any names that are correct already.
+}
+\examples{
+repair_names(list(3, 4, 5)) # works for lists, too
+repair_names(mtcars) # a no-op
+tbl <- as_data_frame(structure(list(3, 4, 5), class = "data.frame"))
+repair_names(tbl)
 }
 

--- a/tests/testthat/test-repair_names.R
+++ b/tests/testthat/test-repair_names.R
@@ -44,7 +44,7 @@ test_that("repair various name problems", {
     expect_true(is.null(old_names) ||
                   any(table(old_names) > 1) ||
                   any(old_names == '' | is.na(old_names)) ||
-                  any(grepl('^ +', old_names)),
+                  any(grepl('^ +| +$', old_names)),
                 info = combo_name)
 
     fixed_dat <- repair_names(dat)
@@ -56,26 +56,8 @@ test_that("repair various name problems", {
     # ensure all valid column names are retained
     if (! is.null(old_names)) {
       valid <- ! is.na(old_names) & old_names != '' &
-        ! duplicated(old_names) & ! grepl('^ +', old_names)
-      expect_true(all(fixed_names[valid] == old_names[valid]))
-    }
-
-    #################################
-    # same test with a list
-    dat <- list(a = 1, b = 2, c = 3)
-    names(dat) <- combos[[ combo_name ]]
-
-    fixed_dat <- repair_names(dat)
-    fixed_names <- names(fixed_dat)
-
-    # no repeats
-    expect_false(any(table(fixed_names) > 1), info = combo_name)
-
-    # ensure all valid names are retained
-    if (! is.null(old_names)) {
-      valid <- ! is.na(old_names) & old_names != '' &
-        ! duplicated(old_names) & ! grepl('^ +', old_names)
-      expect_true(all(fixed_names[valid] == old_names[valid]))
+        ! duplicated(old_names)
+      expect_equal(fixed_names[valid], old_names[valid])
     }
   }
 })
@@ -85,4 +67,8 @@ test_that("check pathological cases", {
   expect_identical(repair_names(df), df)
   df <- data.frame(row.names = 1:3)
   expect_identical(repair_names(df), df)
+  l <- list(3, 4, 5)
+  expect_identical(repair_names(l), setNames(l, paste0("V", 1:3)))
+  l <- list(V = 3, W = 4, 5)
+  expect_identical(repair_names(l), setNames(l, c("V", "W", "V1")))
 })

--- a/tests/testthat/test-repair_names.R
+++ b/tests/testthat/test-repair_names.R
@@ -1,5 +1,11 @@
 context("repair_names")
 
+test_that("trim_ws", {
+  expect_equal(trim_ws(" a"), "a")
+  expect_equal(trim_ws("a "), "a")
+  expect_equal(trim_ws(" a "), "a")
+})
+
 test_that("repair missing column names", {
   dat <- data.frame(a = 1, b = 2, c = 3)
   colnames(dat)[2] <- NA
@@ -40,7 +46,7 @@ test_that("repair various name problems", {
     # ensure we start with a "bad" state
     old_names <- colnames(dat)
     if (!is.null(old_names))
-      old_names <- trimws(old_names)
+      old_names <- trim_ws(old_names)
     expect_true(is.null(old_names) ||
                   any(table(old_names) > 1) ||
                   any(old_names == '' | is.na(old_names)) ||

--- a/tests/testthat/test-repair_names.R
+++ b/tests/testthat/test-repair_names.R
@@ -24,14 +24,14 @@ test_that("repair various name problems", {
                  Spaces = c('a', 'b', ' '),
                  EmptyWithNA = c('', NA, NA),
                  Dup1 = c('a', 'a', 'b'),
-                 Evil1 = c('a', 'a', 'a1'),
+                 Evil1 = c('a', 'a ', 'a1'),
                  OneNA = c('a', 'b', NA),
                  Missing2 = c('', '', 'b'),
                  Vnames1 = c('V1', '', ''),
-                 Vnames2 = c('V2', '', ''),
+                 Vnames2 = c('V2', ' ', ''),
                  Vnames3 = c('V1', '', 'a'),
-                 VnamesDup1 = c('V1', 'V1', 'c'),
-                 VnamesDup2 = c('V1', 'V1', '')
+                 VnamesDup1 = c('V1', ' V1 ', 'c'),
+                 VnamesDup2 = c(' V1', 'V1', '')
                  )
   for (combo_name in names(combos)) {
     dat <- data.frame(a = 1, b = 2, c = 3)
@@ -39,6 +39,8 @@ test_that("repair various name problems", {
 
     # ensure we start with a "bad" state
     old_names <- colnames(dat)
+    if (!is.null(old_names))
+      old_names <- trimws(old_names)
     expect_true(is.null(old_names) ||
                   any(table(old_names) > 1) ||
                   any(old_names == '' | is.na(old_names)) ||

--- a/tests/testthat/test-repair_names.R
+++ b/tests/testthat/test-repair_names.R
@@ -72,3 +72,10 @@ test_that("check pathological cases", {
   l <- list(V = 3, W = 4, 5)
   expect_identical(repair_names(l), setNames(l, c("V", "W", "V1")))
 })
+
+test_that("check object class", {
+  expect_equal(class(iris), class(repair_names(iris)))
+  expect_equal(class(tbl_df(iris)), class(repair_names(tbl_df(iris))))
+  expect_equal(class(repair_names(1:10)), "integer")
+  expect_error(repair_names(cat), "non-vector")
+})


### PR DESCRIPTION
now trims leading and trailing whitespace from names.