### PR TITLE
Cleanup for add_row()

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -286,6 +286,7 @@ column_to_rownames <- function(df, var = "rowname") {
 #' @export
 add_row <- function(.data, ...) {
   df <- data_frame(...)
+  attr(df, "row.names") <- .set_row_names(1L)
 
   extra_vars <- setdiff(names(df), names(.data))
   if (length(extra_vars) > 0) {

--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -300,7 +300,7 @@ add_row <- function(.data, ...) {
   df[missing_vars] <- NA
   df <- df[names(.data)]
 
-  as_data_frame(rbind(.data, df))
+  rbind(.data, df)
 }
 
 # Validity checks --------------------------------------------------------------

--- a/tests/testthat/test-data_frame.R
+++ b/tests/testthat/test-data_frame.R
@@ -178,6 +178,9 @@ test_that("can add new row", {
   expect_identical(df_all_new$a, c(df_all$a, 4))
   expect_identical(df_all_new$b, c(df_all$b, 3L))
   expect_identical(df_all_new$c, c(df_all$c, NA))
+
+  new_iris_row <- add_row(iris)[nrow(iris) + 1, , drop = TRUE]
+  expect_true(all(is.na(new_iris_row)))
 })
 
 test_that("error if adding row with unknown variables", {

--- a/tests/testthat/test-data_frame.R
+++ b/tests/testthat/test-data_frame.R
@@ -179,6 +179,12 @@ test_that("can add new row", {
   expect_identical(df_all_new$b, c(df_all$b, 3L))
   expect_identical(df_all_new$c, c(df_all$c, NA))
 
+  iris_new <- add_row(iris, Species = "unknown")
+  expect_equal(class(iris), class(iris_new))
+
+  iris_new <- add_row(tbl_df(iris), Species = "unknown")
+  expect_equal(class(tbl_df(iris)), class(iris_new))
+
   new_iris_row <- add_row(iris)[nrow(iris) + 1, , drop = TRUE]
   expect_true(all(is.na(new_iris_row)))
 })


### PR DESCRIPTION
- keep object class, in the spirit of c2r and r2c
- fix corner case: all NA added