### PR TITLE
glimpse() gets default width from tibble.width

### DIFF
--- a/R/glimpse.R
+++ b/R/glimpse.R
@@ -11,7 +11,8 @@
 #' \code{data.frames}, and a default method that calls \code{\link{str}}.
 #'
 #' @param x An object to glimpse at.
-#' @param width Width of output: defaults to the width of the console.
+#' @param width Width of output: defaults to the setting of the option
+#'   \code{tibble.width} or the width of the console.
 #' @param ... Other arguments passed onto individual methods.
 #' @return x original x is (invisibly) returned, allowing \code{glimpse} to be
 #' used within a data pipe line.
@@ -22,12 +23,14 @@
 #' if (require("Lahman")) {
 #'   glimpse(Lahman::Batting)
 #' }
-glimpse <- function(x, width = getOption("width"), ...) {
+glimpse <- function(x, width = NULL, ...) {
   UseMethod("glimpse")
 }
 
 #' @export
-glimpse.tbl <- function(x, width = getOption("width"), ...) {
+glimpse.tbl <- function(x, width = NULL, ...) {
+  width <- tibble_width(width)
+
   cat("Observations: ", big_mark(nrow(x)), "\n", sep = "")
   if (ncol(x) == 0) return(invisible())
 
@@ -56,8 +59,8 @@ glimpse.data.frame <- glimpse.tbl
 
 #' @export
 #' @importFrom utils str
-glimpse.default <- function(x, width = getOption("width"), max.level = 3, ...) {
-  str(x, width = width, max.level = max.level, ...)
+glimpse.default <- function(x, width = NULL, max.level = 3, ...) {
+  str(x, width = tibble_width(width), max.level = max.level, ...)
   invisible(x)
 }
 

--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -51,7 +51,7 @@ trunc_mat <- function(x, n = NULL, width = NULL, n_extra = 100) {
   var_types <- vapply(df, type_sum, character(1))
   var_names <- names(df)
 
-  width <- width %||% tibble_opt("width") %||% getOption("width")
+  width <- tibble_width(width)
   if (ncol(df) == 0 || nrow(df) == 0) {
     shrunk <- list(table = NULL, extra = setNames(var_types, var_names))
   } else {
@@ -175,4 +175,8 @@ wrap <- function(..., indent = 0, width) {
 big_mark <- function(x, ...) {
   mark <- if (identical(getOption("OutDec"), ",")) "." else ","
   formatC(x, big.mark = mark, ...)
+}
+
+tibble_width <- function(width) {
+  width %||% tibble_opt("width") %||% getOption("width")
 }

--- a/man/glimpse.Rd
+++ b/man/glimpse.Rd
@@ -4,12 +4,13 @@
 \alias{glimpse}
 \title{Get a glimpse of your data.}
 \usage{
-glimpse(x, width = getOption("width"), ...)
+glimpse(x, width = NULL, ...)
 }
 \arguments{
 \item{x}{An object to glimpse at.}
 
-\item{width}{Width of output: defaults to the width of the console.}
+\item{width}{Width of output: defaults to the setting of the option
+\code{tibble.width} or the width of the console.}
 
 \item{...}{Other arguments passed onto individual methods.}
 }

--- a/tests/testthat/output/glimpse/all-50.txt
+++ b/tests/testthat/output/glimpse/all-50.txt
@@ -1,0 +1,10 @@
+Observations: 2
+Variables: 8
+$ a (dbl) 1.0, 2.5
+$ b (int) 1, 2
+$ c (lgl) TRUE, FALSE
+$ d (chr) "a", "b"
+$ e (fctr) a, b
+$ f (date) 2015-12-10, 2015-12-11
+$ g (time) 2015-12-09 10:51:35, 2015-12-09 10...
+$ h (list) 1, 2

--- a/tests/testthat/test-glimpse.r
+++ b/tests/testthat/test-glimpse.r
@@ -17,6 +17,13 @@ test_that("glimpse output matches known output", {
     glimpse(tbl_df(df_all), width = 70L),
     "glimpse/all-70.txt")
 
+  withr::with_options(
+    list(tibble.width = 50),
+    expect_output_identical(
+      glimpse(tbl_df(df_all)),
+      "glimpse/all-50.txt")
+  )
+
   expect_output_identical(
     glimpse(5),
     "glimpse/5.txt")


### PR DESCRIPTION
just like trunc_mat().

- Extract tibble_width()
- With test

Fixes #35.