### PR TITLE
as_data_frame.default() silently removes row names

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -103,7 +103,7 @@ lst_ <- function(xs) {
 #' This is an S3 generic. tibble includes methods for data frames (adds tbl_df
 #' classes), tbl_dfs (returns unchanged input), lists, matrices, and tables.
 #' Other types are first coerced via \code{\link[base]{as.data.frame}} with
-#' \code{stringsAsFactors = FALSE}.
+#' \code{stringsAsFactors = FALSE} and have their row names removed.
 #'
 #' @param x A list. Each element of the list must have the same length.
 #' @param ... Other arguments passed on to individual methods.
@@ -205,7 +205,7 @@ as_data_frame.NULL <- function(x, ...) {
 #' @rdname as_data_frame
 as_data_frame.default <- function(x, ...) {
   value <- x
-  as_data_frame(as.data.frame(value, stringsAsFactors = FALSE, ...))
+  as_data_frame(remove_rownames(as.data.frame(value, stringsAsFactors = FALSE, ...)))
 }
 
 #' Add a row to a data frame

--- a/man/as_data_frame.Rd
+++ b/man/as_data_frame.Rd
@@ -49,7 +49,7 @@ with more efficient methods for matrices and data frames.
 This is an S3 generic. tibble includes methods for data frames (adds tbl_df
 classes), tbl_dfs (returns unchanged input), lists, matrices, and tables.
 Other types are first coerced via \code{\link[base]{as.data.frame}} with
-\code{stringsAsFactors = FALSE}.
+\code{stringsAsFactors = FALSE} and have their row names removed.
 }
 \examples{
 l <- list(x = 1:500, y = runif(500), z = 500:1)


### PR DESCRIPTION
I'm not really sure this is a good idea. There could be objects where row names are populated during conversion; users would need to do as.data.frame(..., stringsAsFactors = FALSE) %>% rownames_to_column %>% as_data_frame. It seems easier to tolerate row names here.