### PR TITLE
Do not test the class name or attributes of asis_output()

### DIFF
--- a/tests/testthat/test-trunc-mat.R
+++ b/tests/testthat/test-trunc-mat.R
@@ -37,20 +37,14 @@ test_that("trunc_mat output matches known output", {
   expect_output_file_rel(
     cat(knit),
     "trunc_mat/all-knit-60.txt")
-  expect_is(knit, "knit_asis")
-  expect_true(attr(knit, "knit_cacheable"))
 
   knit <- knitr::knit_print(trunc_mat(df_all, width = 120L))
   expect_output_file_rel(
     cat(knit),
     "trunc_mat/all-knit-120.txt")
-  expect_is(knit, "knit_asis")
-  expect_true(attr(knit, "knit_cacheable"))
 
   knit <- knitr::knit_print(trunc_mat(mtcars, width = 60L))
   expect_output_file_rel(
     cat(knit),
     "trunc_mat/mtcars-knit-60.txt")
-  expect_is(knit, "knit_asis")
-  expect_true(attr(knit, "knit_cacheable"))
 })


### PR DESCRIPTION
These are only implementation details of knitr, and can change without notice.