### PR TITLE
Adjust environment of formulas created within lst()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+
+- The formulas created with `lst()` are now set correctly.
+
+
 # tibble 1.0-5 (2016-05-12)
 
 - Indicate presence of row names by a star in printed output (#72).

--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -77,6 +77,8 @@ lst_ <- function(xs) {
     col_names[missing_names] <- defaults
   }
 
+  env <- xs[[1]]$env
+
   # Evaluate each column in turn
   output <- vector("list", n)
   names(output) <- character(n)
@@ -84,6 +86,7 @@ lst_ <- function(xs) {
   for (i in seq_len(n)) {
     res <- lazyeval::lazy_eval(xs[[i]], output)
     if (!is.null(res)) {
+      res <- adjust_nse(res, env)
       output[[i]] <-  res
     }
     names(output)[i] <- col_names[[i]]
@@ -92,6 +95,16 @@ lst_ <- function(xs) {
   output
 }
 
+adjust_nse <- function(x, env) {
+  UseMethod("adjust_nse")
+}
+adjust_nse.default <- function(x, env) {
+  x
+}
+adjust_nse.formula <- function(x, env) {
+  environment(x) <- env
+  x
+}
 
 #' Coerce lists and matrices to data frames.
 #'

--- a/tests/testthat/test-lst.R
+++ b/tests/testthat/test-lst.R
@@ -11,3 +11,7 @@ test_that("lst handles internal references", {
   expect_identical(lst(a = 1, b = a), list(a = 1, b = 1))
   expect_identical(lst(a = NULL, b = a), list(a = NULL, b = NULL))
 })
+
+test_that("lst creates formulas with correct environment", {
+  expect_identical(environment(lst(~x)[[1]]), environment())
+})


### PR DESCRIPTION
This ensures that the environment of formulas created with `lst()` are set to the calling env. Necessary for  hadley/modelr#5