### PR TITLE
Add max string length option

### DIFF
--- a/R/tibble.R
+++ b/R/tibble.R
@@ -39,6 +39,11 @@
   #'   threshold is exceeded. Default: 10.}
   tibble.print_min = 10L,
 
+  #' \item{\code{tibble.print_string_max}}{Printed character threshold: Maximum number of
+  #'   printed characters of a string. Longer strings are abbreviated with \code{"..."}.
+  #'   Default: \code{Inf}}
+  tibble.print_string_max = Inf,
+
   #' \item{\code{tibble.width}}{Output width. Default: \code{NULL} (use
   #'   \code{width} option).}
   tibble.width = NULL,

--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -223,9 +223,13 @@ wrap <- function(..., indent = 0, width) {
 }
 
 
-
 format_character <- function(x) {
   x[is.na(x)] <- "<NA>"
+  max_chars <- getOption("tibble.print_string_max", Inf)
+  if (max_chars < Inf & max_chars >= 4) {
+    longer <- nchar(x) > max_chars
+    x[longer] <- sprintf("%.*s...", max_chars, x[longer])
+  }
   x
 }
 

--- a/tests/testthat/test-trunc-mat.R
+++ b/tests/testthat/test-trunc-mat.R
@@ -85,3 +85,14 @@ test_that("trunc_mat for POSIXlt columns (#86)", {
     print(as_data_frame(df), n = 8L, width = 60L),
     "trunc_mat/POSIXlt-8-30.txt")
 })
+
+test_that("strings are shortend", {
+  vec <- c("a", "123456789", "1234 678901234 67890")
+  exp_10 <- c("a", "123456789", "1234 67890...")
+
+  expect_equal(format_character(vec), vec)
+
+  withr::with_options(
+    list(tibble.print_string_max = 10),
+    expect_equal(format_character(vec), exp_10))
+})


### PR DESCRIPTION
If set to a number, strings longer than this number will be shortend with `...`.

E.g. `options(tibble.print_string_max = 10) will only print up to 10 characters
of each string.