### PR TITLE
Add multiple rows

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -296,7 +296,7 @@ is_tibble <- is.tibble
 #' @export
 add_row <- function(.data, ...) {
   df <- tibble(...)
-  attr(df, "row.names") <- .set_row_names(1L)
+  attr(df, "row.names") <- .set_row_names(max(1L, nrow(df)))
 
   extra_vars <- setdiff(names(df), names(.data))
   if (length(extra_vars) > 0) {

--- a/tests/testthat/test-data_frame.R
+++ b/tests/testthat/test-data_frame.R
@@ -232,3 +232,18 @@ test_that("error if adding row with unknown variables", {
   expect_error(add_row(tibble(a = 3), xxyzy = "err"),
                "would add new variables")
 })
+
+test_that("can add multiple rows", {
+  df <- tibble(a = 3)
+  df_new <- add_row(df, a = 4:5)
+  expect_identical(nrow(df_new), nrow(df) + 2L)
+  expect_identical(df_new$a, c(df$a, 4:5))
+})
+
+test_that("can recycle when adding rows", {
+  iris_new <- add_row(iris, Sepal.Length = -1:-2, Species = "unknown")
+  expect_identical(nrow(iris_new), nrow(iris) + 2L)
+  expect_identical(iris_new$Sepal.Length, c(iris$Sepal.Length, -1:-2))
+  expect_identical(as.character(iris_new$Species),
+                   c(as.character(iris$Species), "unknown", "unknown"))
+})


### PR DESCRIPTION
`add_row()` wasn't actually adding multiple rows. It was just adding one.

It will still add a row of `NA`s when no input is given, which I gather is intentional, from existing tests. My actual interest was in recycling with vector input, hence the test for that.

Demo with one of the examples:

``` r
df <- tibble(x = 1:3, y = 3:1)

## BEFORE
## multiple rows weren't, in fact, being added; also warnings
add_row(df, x = 4:5, y = 0:-1)
#> # A tibble: 4 × 2
#>       x     y
#> * <int> <int>
#> 1     1     3
#> 2     2     2
#> 3     3     1
#> 4     4     0
#> Warning messages:
#> 1: In rbind(deparse.level, ...) :
#>   number of items to replace is not a multiple of replacement length
#> 2: In rbind(deparse.level, ...) :
#>   number of items to replace is not a multiple of replacement length

## AFTER
## vector inputs do add multiple rows, w/ no warnings
add_row(df, x = 4:5, y = 0:-1)
#> # A tibble: 5 × 2
#>       x     y
#> * <int> <int>
#> 1     1     3
#> 2     2     2
#> 3     3     1
#> 4     4     0
#> 5     5    -1
```